### PR TITLE
Add a quick dev environment based on wp-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Run phpunit, eslint, and stylelint using WordPress Coding Standards for any Word
 		"postinstall": "cd ../../pluginade; sh install.sh $npm_package_pluginade_options -p \"${OLDPWD}\";",
 		"reinstall": "cd ../../pluginade; sh install-clean.sh $npm_package_pluginade_options -p \"${OLDPWD}\";",
 		"dev": "cd ../../pluginade; sh dev.sh $npm_package_pluginade_options -p \"${OLDPWD}\";",
+		"dev-env": "cd ../../pluginade; sh dev-env.sh $npm_package_pluginade_options -p \"${OLDPWD}\";",
 		"build": "cd ../../pluginade; sh build.sh $npm_package_pluginade_options -p \"${OLDPWD}\";",
 		"test:phpunit": "cd ../../pluginade; sh phpunit.sh $npm_package_pluginade_options -p \"${OLDPWD}\";",
 		"lint:php": "cd ../../pluginade; sh phpcs.sh $npm_package_pluginade_options -p ${OLDPWD};",

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Run setup.
+. ./setup.sh
+
+# Duplicate the .wp-env.json boiler, and call it .wp-env.json.
+cp wp-env-boiler.json .wp-env.json
+
+# Modify the .wp-env.json file in the pluginade module to contain the path to the plugin in question.
+sed -i.bak "s~PATH_TO_PLUGIN_BEING_TESTED~$plugindir~g" .wp-env.json
+sed -i.bak "s/REPLACE_WITH_PLUGIN_DIR_NAME/$plugindirname/g" .wp-env.json
+
+# Start wp-env
+npx -p @wordpress/env wp-env start
+
+# Run PHPunit inside wp-env, targeting the plugin in question.
+# npx -p @wordpress/env wp-env run --env-cwd='wp-content/pluginade' tests-wordpress vendor/bin/phpunit -c ./phpunit.xml.dist /var/www/html/wp-content/plugins/$plugindirname
+

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -12,7 +12,3 @@ sed -i.bak "s/REPLACE_WITH_PLUGIN_DIR_NAME/$plugindirname/g" .wp-env.json
 
 # Start wp-env
 npx -p @wordpress/env wp-env start
-
-# Run PHPunit inside wp-env, targeting the plugin in question.
-# npx -p @wordpress/env wp-env run --env-cwd='wp-content/pluginade' tests-wordpress vendor/bin/phpunit -c ./phpunit.xml.dist /var/www/html/wp-content/plugins/$plugindirname
-


### PR DESCRIPTION
This PR adds a quick development environment option for testing/building your plugin. 

It makes it so that you can run `npm run dev-env`, and you'll get a WordPress installation at `http://localhost:1000` which you can use to test/build.

We could probably make this better later, but I needed it today, so adding it in the state I used it. 

Things we could probably make better:
- Skip adding node_modules directories to the environment (might speed things up)
- Add the option to indicate a custom port, in case you have multiple plugins you want to test at the same time.
- Add the option to include the entire wp-content directory, in case you want to test 2 plugins together.