### PR TITLE
Switch to new repo for PHPcs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"yoast/phpunit-polyfills": "^1.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"squizlabs/php_codesniffer": "^3.7",
+		"phpcsstandards/php_codesniffer": "^3.7"
 		"wp-coding-standards/wpcs": "^2.3"
 	},
 	"config": {


### PR DESCRIPTION
This PR switched to the new maintained repo for PHPCS:
See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932